### PR TITLE
use mongoid logger and fix id_partition

### DIFF
--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -18,6 +18,12 @@ module Paperclip
 end
 
 ##
+# the id of mongoid is not integer, correct the id_partitioin.
+Paperclip.interpolates :id_partition do |attachment, style|
+  attachment.instance.id.to_s.scan(/.{4}/).join("/")
+end
+
+##
 # The Mongoid::Paperclip extension
 # Makes Paperclip play nice with the Mongoid ODM
 #


### PR DESCRIPTION
I just add two improvements.
1. use mongoid's logger for paperclip.
2. correct the id_partitioin for mongoid's id.
