### PR TITLE
Bug fix: Mongoid::Config is a singleton, so accessing logger accordingly. 

### DIFF
--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -12,7 +12,7 @@ end
 module Paperclip
   class << self
     def logger
-      Mongoid::Config.logger
+      Mongoid::Config.instance.logger
     end
   end
 end


### PR DESCRIPTION
Very simple change, I'm not sure whether the Mongoid::Config class has been changed to a singleton, but without this fix, I get loads of errors when running my rspec tests.

Feedback very welcome, I'm fairly new to Ruby/Rails so please go easy!

Thanks.
