### PR TITLE
Fixes the logger issue properly

### DIFF
--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -15,7 +15,7 @@ module Paperclip
       if Mongoid::Config.logger.present?
         Mongoid::Config.logger
       else
-        super
+        Rails.logger
       end
     end
   end


### PR DESCRIPTION
Hey,

So there are times when Mongoid.config.logger is nil (for example when you want to disable logging queries for performance). In this instance we need to pass a real logger. Hence this patch.
