### PR TITLE
Stop patching Paperclip.logger

### DIFF
--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -8,20 +8,6 @@ rescue LoadError
 end
 
 ##
-# Use mongoid's logger.
-module Paperclip
-  class << self
-    def logger
-      if Mongoid::Config.logger.present?
-        Mongoid::Config.logger
-      else
-        Rails.logger
-      end
-    end
-  end
-end
-
-##
 # the id of mongoid is not integer, correct the id_partitioin.
 Paperclip.interpolates :id_partition do |attachment, style|
   attachment.instance.id.to_s.scan(/.{4}/).join("/")


### PR DESCRIPTION
When using mongoid-paperclip with the latest Mongoid(3.0.0), mongoid-paperclip's Paperclip.logger causes error because Mongoid 3.0.0 doesn't have Mongoid::Config.logger, which was replaced by Mongoid.logger. 

Considering that Paperclip no longer have hardcoded ActiveRecord logger
(This change was made by https://github.com/thoughtbot/paperclip/commit/6b6ce9edf7eef4c9bb722bf4f69eb0f63e959ae3),
I think removing the patch will be the right move to fix the problem here(and it should also fixes #20).

Thanks for publishing and maintaining this useful gem!
