### PR TITLE
MongoID 3.0 compatibility + refactoring

### DIFF
--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -12,7 +12,9 @@ end
 module Paperclip
   class << self
     def logger
-      begin
+      if Mongoid.respond_to?(:logger) # mongoid 3
+        Mongoid.logger
+      elsif Mongoid::Config.respond_to?(:logger) # mongoid 2
         Mongoid::Config.logger
       else
         Rails.logger


### PR DESCRIPTION
Hey Michael,

I've added a patch for mongoid 3.0 compatibility + refactoring things a bit, moved the `include Paperclip` calls into the `self.include` section where it belongs to.

Also, if you don't mind i've made the original `has_attached_file` method work, it seems a bit silly to define your own method in this case.

Cheers,
Nik
