### PR TITLE
do not mess with the id partition

### DIFF
--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -8,12 +8,6 @@ rescue LoadError
 end
 
 ##
-# the id of mongoid is not integer, correct the id_partitioin.
-Paperclip.interpolates :id_partition do |attachment, style|
-  attachment.instance.id.to_s.scan(/.{4}/).join("/")
-end
-
-##
 # mongoid criteria uses a different syntax.
 module Paperclip
   module Helpers
@@ -62,7 +56,7 @@ module Mongoid
     end
 
     module ClassMethods
-    
+
       ##
       # Adds after_commit
       def after_commit(*args, &block)

--- a/mongoid-paperclip.gemspec
+++ b/mongoid-paperclip.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = %x[git ls-files -- {spec}/*].split("\n")
   gem.require_path  = 'lib'
 
-  gem.add_dependency 'paperclip', ['>= 2.3.6']
+  gem.add_dependency 'paperclip', ['>= 4.2.0']
 end


### PR DESCRIPTION
In paperclip 4.2 they already accept strings for the id's

The current implementation will break the id partition in non mongoid records. This fixes that.