### PR TITLE
Allow disabling fingerprinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ end
 @user.update_attributes({ ... :pictures => [...] })
 ```
 
+## Optional fingerprinting
+
+Paperclip will skip calculating the fingerprint of a file when the `{file}_fingerprint` field is missing from the model. This can be desirable if attaching large files to a model. To disable adding the fingerprint field pass the `disable_fingerprint` option as in this example:
+
+```rb
+class User
+  include Mongoid::Document
+  include Mongoid::Paperclip
+
+  has_mongoid_attached_file :usage_report, disable_fingerprint: true
+end
+```
+
 ## There you go
 
 Quite a lot of people have been looking for a solution to use Paperclip with Mongoid so I hope this helps!

--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -62,7 +62,7 @@ module Mongoid
     end
 
     module ClassMethods
-    
+
       ##
       # Adds after_commit
       def after_commit(*args, &block)
@@ -89,6 +89,7 @@ module Mongoid
       # it'll also add the required fields for Paperclip since MongoDB is schemaless and doesn't
       # have migrations.
       def has_mongoid_attached_file(field, options = {})
+        disable_fingerprint = options.delete(:disable_fingerprint)
 
         ##
         # Include Paperclip and Paperclip::Glue for compatibility
@@ -108,7 +109,7 @@ module Mongoid
         field(:"#{field}_content_type", :type => String)
         field(:"#{field}_file_size",    :type => Integer)
         field(:"#{field}_updated_at",   :type => DateTime)
-        field(:"#{field}_fingerprint",  :type => String)
+        field(:"#{field}_fingerprint",  :type => String) unless disable_fingerprint
       end
 
       ##


### PR DESCRIPTION
Add an option to disable the `fingerprint` field. `papertrail` will avoid calculating the fingerprint when this field is missing which is desired when attaching large files. e.g. x00MB csv files. 