### PR TITLE
Update to gem Specs

### DIFF
--- a/mongoid-paperclip.gemspec
+++ b/mongoid-paperclip.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = %x[git ls-files -- {spec}/*].split("\n")
   gem.require_path  = 'lib'
 
-  gem.add_dependency 'paperclip', ['>= 2.3.6', '!=4.3.0']
+  gem.add_dependency 'paperclip', ['>= 2.3.6', '!=4.3.0', '!=4.3.3']
 end


### PR DESCRIPTION
The new version of paperclip (4.3.3 - January 29, 2016) is not compatible with mongoid-paperclip.