### PR TITLE
Fix destructive modification of hook params

### DIFF
--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -66,7 +66,7 @@ module Mongoid
       ##
       # Adds after_commit
       def after_commit(*args, &block)
-        options = args.pop if args.last.is_a? Hash
+        options = args.last if args.last.is_a? Hash
         if options
           case options[:on]
           when :create


### PR DESCRIPTION
Currently, the `after_commit` compatibility layer does not pass through `options`. This means that options like conditionals are not passed through, which breaks things in strange ways.

For a concrete example - devise confirmable preferences `after_commit` and relies on `:if` conditions for sending confirmation email. So a user model with an avatar will fail without this fix.