### PR TITLE
Fix id_partition interpolation with BSON::ObjectId

### DIFF
--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -6,8 +6,8 @@ Paperclip.interpolates :id_partition do |attachment, style|
   case id = attachment.instance.id
   when Integer
     ("%09d".freeze % id).scan(/\d{3}/).join("/".freeze)
-  when String
-    id.scan(/.{4}/).join("/".freeze)
+  when String, BSON::ObjectId
+    id.to_s.scan(/.{4}/).join("/".freeze)
   else
     nil
   end

--- a/spec/mongoid-paperclip_spec.rb
+++ b/spec/mongoid-paperclip_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Mongoid::Paperclip, type: :unit do
     it "stores fingerprint" do
       expect(user.avatar_fingerprint).to eq("2584a801e588b3fcf4aa074efff77e30")
     end
+
+    it "interpolates path and url properly" do
+      id_partition = user.id.to_s.scan(/.{4}/).join("/")
+      expect(user.avatar.url).to eq("/system/users/#{id_partition}/avatar-original.png?#{Time.now.to_i}")
+      expect(user.avatar.path).to eq("#{__dir__}/public/system/users/#{id_partition}/avatar-original.png")
+    end
   end
 
   describe "multiple attachments" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ class User
   include Mongoid::Document
   include Mongoid::Paperclip
 
-  has_mongoid_attached_file :avatar
+  has_mongoid_attached_file :avatar, url: "/system/:class/:id_partition/:basename-:style.:extension"
   validates_attachment_content_type :avatar, content_type: /\Aimage\/.*\Z/
 end
 


### PR DESCRIPTION
Hey all  :wave: 

I noticed recently that `id_partition` interpolation was not working any more in my project, it was always `nil`.
As I investigated I noticed the reason is quite simple, the code expects the model instance `id` to be a `String`, whereas it's a `BSON::ObjectId` (and it has been so for a while in mongoid).

I suspect it was probably a String in earlier version of mongoid? At some point it was working fine in my code because I have old folders with the `id_partition` but I can't tell exactly when it stopped working because I delete old files regularly.

Anyway here is the fix I suggest (with an addition test for that): I added `BSON::ObjectId` to the supported types and `.to_s` to convert it to a `String` before the `scan`. (`.to_s` is a no-op if already a String). I tested this fix in my project and it restored the working `id_partition` interpolation.

New test before my fix showing the problem:
![image](https://user-images.githubusercontent.com/201687/155877787-6dbb1855-3ec4-4904-876f-13fa6803de8b.png)

Let me know if you have any questions!