### PR TITLE
Change {image}_updated_at to Time (was DateTime)

### DIFF
--- a/lib/mongoid_paperclip.rb
+++ b/lib/mongoid_paperclip.rb
@@ -108,7 +108,7 @@ module Mongoid
         field(:"#{field}_file_name",    :type => String)
         field(:"#{field}_content_type", :type => String)
         field(:"#{field}_file_size",    :type => Integer)
-        field(:"#{field}_updated_at",   :type => DateTime)
+        field(:"#{field}_updated_at",   :type => Time)
         field(:"#{field}_fingerprint",  :type => String) unless disable_fingerprint
       end
 


### PR DESCRIPTION
For `{image}_updated_at field`, type `Time` is better to use than `DateTime`.
- It has better performance
- It's what Mongoid uses for created_at / updated_at timestamps.
- This change can be done without needing to migrate the data in the database.
- For the vast majority of apps this will not have an real impact, since ActiveSupport standardizes the main methods of Time/DateTime.